### PR TITLE
Related-Bug: #1512927, Relate-Bug: #1476413

### DIFF
--- a/webroot/setting/sm/test/ui/models/PackageModel.test.js
+++ b/webroot/setting/sm/test/ui/models/PackageModel.test.js
@@ -2,7 +2,7 @@ define([
     'co-test-runner',
     'sm-test-utils',
     'sm-test-messages',
-    'package-model-mock-data',
+    'setting/sm/test/ui/models/PackageModel.mock.data',
     'co-form-model-validations-test-suite',
     'package-model-custom-test-suite',
 ], function (cotr, smtu, smtm, PackageModelMockData, FormValidationsTestSuite, PackageModelCustomTestSuite) {
@@ -21,7 +21,6 @@ define([
                         {
                             class: FormValidationsTestSuite,
                             groups: ['all'],
-                            severity: cotc.SEVERITY_LOW,
                             modelConfig: {
                                 mockData: PackageModelMockData,
                                 validationKey: smwc.KEY_CONFIGURE_VALIDATION,
@@ -30,7 +29,6 @@ define([
                         {
                             class: PackageModelCustomTestSuite,
                             groups: ['all'],
-                            severity: cotc.SEVERITY_LOW,
                             modelConfig: {
                                 mockData: PackageModelMockData,
                                 dataParsers: {

--- a/webroot/setting/sm/test/ui/views/ClusterListView.custom.test.suite.js
+++ b/webroot/setting/sm/test/ui/views/ClusterListView.custom.test.suite.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'co-test-utils',
+    'co-test-constants',
+    'co-test-runner',
+    'sm-test-messages',
+], function (_, cotu, cotc, cotr, smtm) {
+    var testSuiteClass = function (viewObj, suiteConfig) {
+
+        var viewConfig = cotu.getViewConfigObj(viewObj),
+            el = viewObj.el,
+            gridData = $(el).data('contrailGrid'),
+            gridItems = gridData._dataView.getItems();
+
+        module(cotu.formatTestModuleMessage(smtm.CLUSTER_LIST_VIEW_CUSTOM_TEST_MODULE, el.id));
+
+        var gridViewCustomTestSuite = cotr.createTestSuite('GridViewCustomTestSuite');
+
+        /**
+         * Grid Body group Custom test cases
+         */
+
+        var bodyTestGroup = gridViewCustomTestSuite.createTestGroup('body');
+
+        bodyTestGroup.registerTest(cotr.test("Test number of bubbles with filter on grid", function(assert) {
+            expect(2);
+
+            var inputBox = $(el).find('.input-grid-search');
+            inputBox.val('main');
+            inputBox.keyup();
+
+            var isDone1 = assert.async();
+
+            setTimeout(function(){
+                equal($('#cluster-scatter-chart').find('.zoom-scatter-chart').find('circle').length, 1,
+                    "Number of bubbles in chart should be equal to the chart data");
+
+                // filter with a non-existing key and check zero bubbles
+                inputBox.val('abc');
+                inputBox.keyup();
+                var isDone2 = assert.async();
+                setTimeout(function(){
+                    equal($('#cluster-scatter-chart').find('.zoom-scatter-chart').find('circle').length, 0,
+                        "Number of bubbles in chart should be equal to the chart data");
+                    isDone2();
+                }, cotc.ASSERT_TIMEOUT);
+                isDone1();
+            }, cotc.ASSERT_TIMEOUT);
+
+        }, cotc.SEVERITY_MEDIUM));
+
+        gridViewCustomTestSuite.run(suiteConfig.groups, suiteConfig.severity);
+
+    };
+
+    return testSuiteClass;
+});

--- a/webroot/setting/sm/test/ui/views/ClusterListView.test.js
+++ b/webroot/setting/sm/test/ui/views/ClusterListView.test.js
@@ -2,11 +2,13 @@ define([
     'co-test-runner',
     'sm-test-utils',
     'sm-test-messages',
-    'cluster-list-view-mock-data',
+    'setting/sm/test/ui/views/ClusterListView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite',
     'co-chart-view-zoom-scatter-test-suite',
-], function (cotr, smtu, smtm, ClusterListViewMockData, GridListModelTestSuite, GridViewTestSuite, ZoomScatterChartViewTestSuite) {
+    'cluster-list-view-custom-test-suite'
+], function (cotr, smtu, smtm, ClusterListViewMockData, GridListModelTestSuite, GridViewTestSuite,
+             ZoomScatterChartViewTestSuite, ClusterListViewCustomTestSuite) {
 
     var moduleId = smtm.CLUSTER_LIST_VIEW_COMMON_TEST_MODULE;
 
@@ -45,7 +47,7 @@ define([
     pageConfig.hashParams = {
         p: 'setting_sm_clusters'
     };
-    pageConfig.loadTimeout = 3000;
+    pageConfig.loadTimeout = cotc.PAGE_LOAD_TIMEOUT * 3;
 
     var getTestConfig = function () {
         return {
@@ -56,8 +58,7 @@ define([
                 suites: [
                     {
                         class: ZoomScatterChartViewTestSuite,
-                        groups: ['all'],
-                        severity: cotc.SEVERITY_LOW
+                        groups: ['all']
                     }
                 ]
             },
@@ -66,13 +67,21 @@ define([
                     suites: [
                         {
                             class: GridViewTestSuite,
-                            groups: ['all'],
-                            severity: cotc.SEVERITY_LOW
+                            groups: ['all']
                         },
                         {
                             class: GridListModelTestSuite,
                             groups: ['all'],
-                            severity: cotc.SEVERITY_LOW,
+                            modelConfig: {
+                                dataGenerator: smtu.commonGridDataGenerator,
+                                dataParsers: {
+                                    gridDataParseFn: smtu.deleteFieldsForClusterScatterChart
+                                }
+                            }
+                        },
+                        {
+                            class: ClusterListViewCustomTestSuite,
+                            groups: ['all'],
                             modelConfig: {
                                 dataGenerator: smtu.commonGridDataGenerator,
                                 dataParsers: {

--- a/webroot/setting/sm/test/ui/views/ClusterTabView.test.js
+++ b/webroot/setting/sm/test/ui/views/ClusterTabView.test.js
@@ -2,7 +2,7 @@ define([
     'co-test-runner',
     'sm-test-utils',
     'sm-test-messages',
-    'cluster-tab-view-mock-data',
+    'setting/sm/test/ui/views/ClusterTabView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite',
     'co-details-view-test-suite'
@@ -53,7 +53,7 @@ define([
             cluster_id : "r22_cluster"
         }
     };
-    pageConfig.loadTimeout = 5000;
+    pageConfig.loadTimeout = cotc.PAGE_LOAD_TIMEOUT * 2;
 
     var getTestConfig = function () {
         return {
@@ -65,7 +65,6 @@ define([
                         {
                             class: DetailsViewTestSuite,
                             groups: ['all'],
-                            severity: cotc.SEVERITY_LOW,
                             modelConfig: {
                                 dataGenerator: smtu.commonDetailsDataGenerator
                             }
@@ -77,13 +76,11 @@ define([
                     suites: [
                         {
                             class: GridViewTestSuite,
-                            groups: ['all'],
-                            severity: cotc.SEVERITY_LOW
+                            groups: ['all']
                         },
                         {
                             class: GridListModelTestSuite,
                             groups: ['all'],
-                            severity: cotc.SEVERITY_LOW,
                             modelConfig: {
                                 dataGenerator: smtu.commonGridDataGenerator,
                                 dataParsers: {

--- a/webroot/setting/sm/test/ui/views/ImageListView.test.js
+++ b/webroot/setting/sm/test/ui/views/ImageListView.test.js
@@ -2,7 +2,7 @@ define([
     'co-test-runner',
     'sm-test-utils',
     'sm-test-messages',
-    'image-list-view-mock-data',
+    'setting/sm/test/ui/views/ImageListView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
 ], function (cotr, smtu, smtm, ImageListViewMockData, GridListModelTestSuite, GridViewTestSuite) {
@@ -33,7 +33,7 @@ define([
     pageConfig.hashParams = {
         p: 'setting_sm_images'
     };
-    pageConfig.loadTimeout = 1000;
+    pageConfig.loadTimeout = cotc.PAGE_LOAD_TIMEOUT;
 
     var getTestConfig = function () {
         return {
@@ -44,13 +44,11 @@ define([
                     suites: [
                         {
                             class: GridViewTestSuite,
-                            groups: ['all'],
-                            severity: cotc.SEVERITY_LOW
+                            groups: ['all']
                         },
                         {
                             class: GridListModelTestSuite,
                             groups: ['all'],
-                            severity: cotc.SEVERITY_LOW,
                             modelConfig: {
                                 dataGenerator: smtu.commonGridDataGenerator,
                                 dataParsers: {

--- a/webroot/setting/sm/test/ui/views/PackageListView.test.js
+++ b/webroot/setting/sm/test/ui/views/PackageListView.test.js
@@ -6,7 +6,7 @@ define([
     'co-test-runner',
     'sm-test-utils',
     'sm-test-messages',
-    'package-list-view-mock-data',
+    'setting/sm/test/ui/views/PackageListView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
 ], function (cotr, smtu, smtm, PackageListViewMockData, GridListModelTestSuite, GridViewTestSuite) {
@@ -37,7 +37,7 @@ define([
     pageConfig.hashParams = {
         p: 'setting_sm_packages'
     };
-    pageConfig.loadTimeout = 1000;
+    pageConfig.loadTimeout = cotc.PAGE_LOAD_TIMEOUT;
 
     var getTestConfig = function () {
         return {
@@ -48,13 +48,11 @@ define([
                     suites: [
                         {
                             class: GridViewTestSuite,
-                            groups: ['all'],
-                            severity: cotc.SEVERITY_LOW
+                            groups: ['all']
                         },
                         {
                             class: GridListModelTestSuite,
                             groups: ['all'],
-                            severity: cotc.SEVERITY_LOW,
                             modelConfig: {
                                 dataGenerator: smtu.commonGridDataGenerator,
                                 dataParsers: {

--- a/webroot/setting/sm/test/ui/views/ServerListView.test.js
+++ b/webroot/setting/sm/test/ui/views/ServerListView.test.js
@@ -2,7 +2,7 @@ define([
     'co-test-runner',
     'sm-test-utils',
     'sm-test-messages',
-    'server-list-view-mock-data',
+    'setting/sm/test/ui/views/ServerListView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite',
     'co-chart-view-zoom-scatter-test-suite',
@@ -50,7 +50,7 @@ define([
     pageConfig.hashParams = {
         p: 'setting_sm_servers'
     };
-    pageConfig.loadTimeout = 5000;
+    pageConfig.loadTimeout = cotc.PAGE_LOAD_TIMEOUT * 5;
 
     var getTestConfig = function () {
         return {
@@ -61,8 +61,7 @@ define([
                     suites: [
                         {
                             class: ZoomScatterChartViewTestSuite,
-                            groups: ['all'],
-                            severity: cotc.SEVERITY_LOW
+                            groups: ['all']
                         }
                     ]
                 },
@@ -71,13 +70,11 @@ define([
                     suites: [
                         {
                             class: GridViewTestSuite,
-                            groups: ['all'],
-                            severity: cotc.SEVERITY_LOW
+                            groups: ['all']
                         },
                         {
                             class: GridListModelTestSuite,
                             groups: ['all'],
-                            severity: cotc.SEVERITY_LOW,
                             modelConfig: {
                                 dataGenerator: smtu.commonGridDataGenerator,
                                 dataParsers: {

--- a/webroot/setting/sm/test/ui/views/ServerTabView.test.js
+++ b/webroot/setting/sm/test/ui/views/ServerTabView.test.js
@@ -2,7 +2,7 @@ define([
     'co-test-runner',
     'sm-test-utils',
     'sm-test-messages',
-    'server-tab-view-mock-data',
+    'setting/sm/test/ui/views/ServerTabView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite',
     'co-details-view-test-suite'
@@ -66,7 +66,7 @@ define([
             server_id : "a7s12"
         }
     };
-    pageConfig.loadTimeout = 5000;
+    pageConfig.loadTimeout = cotc.PAGE_LOAD_TIMEOUT * 5;
 
     var getTestConfig = function () {
         return {
@@ -78,7 +78,6 @@ define([
                         {
                             class: DetailsViewTestSuite,
                             groups: ['all'],
-                            severity: cotc.SEVERITY_LOW,
                             modelConfig: {
                                 dataGenerator: smtu.commonDetailsDataGenerator
                             }
@@ -112,8 +111,7 @@ define([
                     suites: [
                         {
                             class: GridViewTestSuite,
-                            groups: ['all'],
-                            severity: cotc.SEVERITY_LOW
+                            groups: ['all']
                         }
                     ]
                 },
@@ -124,7 +122,7 @@ define([
         };
     };
 
-    var testInitFn = function() {
+    var testInitFn = function(defObj) {
         //simulate click on all the tabs
         var serverTabsViewObj = smPageLoader.smView.viewMap[smwl.SM_SERVER_TAB_VIEW_ID],
             serverTabs = serverTabsViewObj.attributes.viewConfig.tabs;
@@ -132,7 +130,9 @@ define([
         _.each(serverTabs, function(tab) {
             $("#" + tab.elementId + "-tab-link").trigger("click");
         });
-
+        setTimeout(function() {
+                defObj.resolve();
+        }, cotc.PAGE_INIT_TIMEOUT);
         return;
     };
 

--- a/webroot/test/ui/Gruntfile.js
+++ b/webroot/test/ui/Gruntfile.js
@@ -69,8 +69,10 @@ module.exports = function (grunt) {
                     'contrail-web-server-manager/webroot/setting/sm/ui/js/**/Image*.js': ['coverage']
                 },
                 junitReporter: {
-                    outputFile: __dirname + '/reports/tests/sm/views/image-test-results.xml',
+                    outputDir: __dirname + '/reports/tests/sm/views/',
+                    outputFile: 'image-test-results.xml',
                     suite: 'ImageListView',
+                    useBrowserName: false
                 },
                 htmlReporter: {
                     outputFile: __dirname + '/reports/tests/sm/views/image-list-view-test-results.html'
@@ -95,8 +97,10 @@ module.exports = function (grunt) {
                     'contrail-web-server-manager/webroot/setting/sm/ui/js/**/Package*.js': ['coverage']
                 },
                 junitReporter: {
-                    outputFile: __dirname + '/reports/tests/sm/views/package-test-results.xml',
+                    outputDir: __dirname + '/reports/tests/sm/views/',
+                    outputFile: 'package-test-results.xml',
                     suite: 'PackageListView',
+                    useBrowserName: false
                 },
                 htmlReporter: {
                     outputFile: __dirname + '/reports/tests/sm/views/package-list-view-test-results.html'
@@ -121,8 +125,10 @@ module.exports = function (grunt) {
                     'contrail-web-server-manager/webroot/setting/sm/ui/js/**/Cluster*.js': ['coverage']
                 },
                 junitReporter: {
-                    outputFile: __dirname + '/reports/tests/sm/views/cluster-tab-view-test-results.xml',
+                    outputDir: __dirname + '/reports/tests/sm/views/',
+                    outputFile: 'cluster-tab-view-test-results.xml',
                     suite: 'ClusterTabView',
+                    useBrowserName: false
                 },
                 htmlReporter: {
                     outputFile: __dirname + '/reports/tests/sm/views/cluster-tab-view-test-results.html'
@@ -144,8 +150,10 @@ module.exports = function (grunt) {
         //            'contrail-web-server-manager/webroot/setting/sm/ui/js/**/Server*.js': ['coverage']
         //        },
         //        junitReporter: {
-        //            outputFile: __dirname + '/reports/tests/sm/views/server-tab-view-test-results.xml',
+        //            outputDir: __dirname + '/reports/tests/sm/views/',
+        //            outputFile: 'server-tab-view-test-results.xml',
         //            suite: 'servers',
+        //            useBrowserName: false
         //        },
         //        htmlReporter: {
         //            outputFile: __dirname + '/reports/tests/sm/views/server-tab-view-test-results.html'
@@ -164,14 +172,20 @@ module.exports = function (grunt) {
                     {
                         pattern: 'contrail-web-server-manager/webroot/setting/sm/test/ui/views/ClusterListView.test.js',
                         included: false
+                    },
+                    {
+                        pattern: 'contrail-web-server-manager/webroot/setting/sm/test/ui/views/ClusterListView.custom.test.suite.js',
+                        included: false
                     }
                 ],
                 preprocessors: {
                     'contrail-web-server-manager/webroot/setting/sm/ui/js/**/Cluster*.js': ['coverage']
                 },
                 junitReporter: {
-                    outputFile: __dirname + '/reports/tests/sm/views/cluster-list-view-test-results.xml',
+                    outputDir: __dirname + '/reports/tests/sm/views/',
+                    outputFile: 'cluster-list-view-test-results.xml',
                     suite: 'clusters',
+                    useBrowserName: false
                 },
                 htmlReporter: {
                     outputFile: __dirname + '/reports/tests/sm/views/cluster-list-view-test-results.html'
@@ -196,8 +210,10 @@ module.exports = function (grunt) {
                     'contrail-web-server-manager/webroot/setting/sm/ui/js/**/Server*.js': ['coverage']
                 },
                 junitReporter: {
-                    outputFile: __dirname + '/reports/tests/sm/views/server-list-view-test-results.xml',
+                    outputDir: __dirname + '/reports/tests/sm/views/',
+                    outputFile: 'server-list-view-test-results.xml',
                     suite: 'servers',
+                    useBrowserName: false
                 },
                 htmlReporter: {
                     outputFile: __dirname + '/reports/tests/sm/views/server-list-view-test-results.html'
@@ -220,8 +236,10 @@ module.exports = function (grunt) {
         //            'contrail-web-server-manager/webroot/setting/sm/ui/js/models/*Model.js': ['coverage']
         //        },
         //        junitReporter: {
-        //            outputFile: __dirname + '/reports/tests/sm/models/package-model-test-results.xml',
+        //            outputDir: __dirname + '/reports/tests/sm/models/',
+        //            outputFile: 'package-model-test-results.xml',
         //            suite: 'models',
+        //            useBrowserName: false
         //        },
         //        htmlReporter: {
         //            outputFile: __dirname + '/reports/tests/sm/models/package-model-test-results.html'
@@ -254,11 +272,14 @@ module.exports = function (grunt) {
         options: {
             files: [],
             preprocessors: {
-                'contrail-web-server-manager/webroot/setting/sm/ui/js/**/*.js': ['coverage']
+                'contrail-web-server-manager/webroot/setting/sm/ui/js/**/*.js': ['coverage'],
+                'contrail-web-core/webroot/js/**/*.js': ['coverage']
             },
             junitReporter: {
-                outputFile: __dirname + '/reports/tests/sm/sm-test-results.xml',
+                outputDir: __dirname + '/reports/tests/sm/',
+                outputFile: 'sm-test-results.xml',
                 suite: 'sm',
+                useBrowserName: false
             },
             htmlReporter: {
                 outputFile: __dirname + '/reports/tests/sm/sm-test-results.html'
@@ -283,11 +304,14 @@ module.exports = function (grunt) {
         options: {
             files: [],
             preprocessors: {
-                'contrail-web-server-manager/webroot/**/ui/js/**/*.js': ['coverage']
+                'contrail-web-server-manager/webroot/**/ui/js/**/*.js': ['coverage'],
+                'contrail-web-core/webroot/js/**/*.js': ['coverage']
             },
             junitReporter: {
-                outputFile: __dirname + '/reports/tests/server-manager-test-results.xml',
+                outputDir: __dirname + '/reports/tests/',
+                outputFile: 'server-manager-test-results.xml',
                 suite: 'serverManager',
+                useBrowserName: false
             },
             htmlReporter: {
                 outputFile: __dirname + '/reports/tests/server-manager-test-results.html'

--- a/webroot/test/ui/karma.config.js
+++ b/webroot/test/ui/karma.config.js
@@ -24,13 +24,16 @@ module.exports = function (config) {
             //'Firefox',
             //'Chrome'
         ],
-
+        exclude: [
+            '**/node_modules/**/*.test.js',
+        ],
         //port: 8143,
 
         reporters: ['progress', 'html', 'coverage', 'junit'],
         // the default configuration
         junitReporter: {
-            outputFile: __dirname + '/reports/test-results.xml',
+            outputDir: __dirname + '/reports/tests/',
+            outputFile: 'test-results.xml',
             suite: ''
         },
         preprocessors: {
@@ -38,7 +41,7 @@ module.exports = function (config) {
             '*.tmpl': ['html2js']
         },
         htmlReporter: {
-            outputFile: __dirname + '/reports/test-results.html'
+            outputFile: __dirname + '/reports/tests/test-results.html'
         },
         coverageReporter: {
             type : 'html',

--- a/webroot/test/ui/sm.test.app.js
+++ b/webroot/test/ui/sm.test.app.js
@@ -49,18 +49,11 @@ require([
 
         serverManagerTestAppPathObj ["sm-test-messages"] = smBaseDir + "/test/ui/sm.test.messages";
         serverManagerTestAppPathObj ["sm-test-utils"] = smBaseDir + "/test/ui/sm.test.utils";
-
         serverManagerTestAppPathObj ["handlebars-helpers"] = smBaseDir + "/common/ui/js/handlebars.helpers";
-        serverManagerTestAppPathObj ["image-list-view-mock-data"] = smBaseDir + "/setting/sm/test/ui/views/ImageListView.mock.data";
-        serverManagerTestAppPathObj ["package-list-view-mock-data"] = smBaseDir + "/setting/sm/test/ui/views/PackageListView.mock.data";
-        serverManagerTestAppPathObj ["cluster-list-view-mock-data"] = smBaseDir + "/setting/sm/test/ui/views/ClusterListView.mock.data";
-        serverManagerTestAppPathObj ["server-list-view-mock-data"] = smBaseDir + "/setting/sm/test/ui/views/ServerListView.mock.data";
 
-        serverManagerTestAppPathObj ["cluster-tab-view-mock-data"] = smBaseDir + "/setting/sm/test/ui/views/ClusterTabView.mock.data";
-        serverManagerTestAppPathObj ["server-tab-view-mock-data"] = smBaseDir + "/setting/sm/test/ui/views/ServerTabView.mock.data";
+        serverManagerTestAppPathObj ["cluster-list-view-custom-test-suite"] = smBaseDir + "/setting/sm/test/ui/views/ClusterListView.custom.test.suite";
 
         serverManagerTestAppPathObj ["package-model-custom-test-suite"] = smBaseDir + "/setting/sm/test/ui/models/PackageModel.custom.test.suite";
-        serverManagerTestAppPathObj ["package-model-mock-data"] = smBaseDir + "/setting/sm/test/ui/models/PackageModel.mock.data";
 
         return serverManagerTestAppPathObj;
     };

--- a/webroot/test/ui/sm.test.messages.js
+++ b/webroot/test/ui/sm.test.messages.js
@@ -12,6 +12,7 @@ define([
     this.SERVER_LIST_VIEW_COMMON_TEST_MODULE = 'Server List view - Common Tests';
     this.IMAGE_LIST_VIEW_COMMON_TEST_MODULE = 'Image List view - Common Tests';
     this.PACKAGE_MODEL_TEST_MODULE = 'Package Model - Form Edit Tests';
+    this.CLUSTER_LIST_VIEW_CUSTOM_TEST_MODULE = 'Cluster List view - Custom Tests';
 
     this.get = function () {
         var args = arguments;
@@ -28,6 +29,7 @@ define([
         SERVER_LIST_VIEW_COMMON_TEST_MODULE: SERVER_LIST_VIEW_COMMON_TEST_MODULE,
         IMAGE_LIST_VIEW_COMMON_TEST_MODULE: IMAGE_LIST_VIEW_COMMON_TEST_MODULE,
         PACKAGE_MODEL_TEST_MODULE: PACKAGE_MODEL_TEST_MODULE,
+        CLUSTER_LIST_VIEW_CUSTOM_TEST_MODULE: CLUSTER_LIST_VIEW_CUSTOM_TEST_MODULE,
         get: get
     };
 });


### PR DESCRIPTION
1. updates to Gruntfile and karma to support updated test infra libarary.
2. karma updated to 0.12.37
3. will exclude the test files getting added from node_modules/**/ dir
4. other changes in reporters and coverage has been already checked in
5. junit reporter needs sperate dir configuration.
6. tests will be run using the RUN_SEVERITY configured in the constants file.
removed suite severity attribute since it wont be used to control.
7. page load timeout, page init timeout and assert timeout constants will be used from core constants.
8. adding custom test suite for ClusterListView
new assert timeout will be used for async call to finish

Change-Id: I8eec14acb162ed613130d5497095c4a0900c9f88