### PR TITLE
Related-Bug: #1476413 test infra bug fixes

### DIFF
--- a/webroot/test/ui/run_tests.sh
+++ b/webroot/test/ui/run_tests.sh
@@ -1,12 +1,27 @@
 #!/usr/bin/env bash
 # We will use the grunt binary from the node_modules locally installed.
 
-TEST_CONFIG=./../contrail-web-core/webroot/test/ui/js/co.test.config.js
-ENV=`grep 'testConfig.env' $TEST_CONFIG |grep -o "\'[^>]*\'"`
-GRUNT_DIR=./node_modules/grunt-cli
-GRUNT_FILE=webroot/test/ui/Gruntfile.js
+ROOT_DIR=.
+if [ ${PWD##*/} = "ui" ]; then
+    ROOT_DIR=./../../..
+fi
+TEST_DIR=webroot/test/ui
+TEST_CONFIG=$ROOT_DIR/../contrail-web-core/$TEST_DIR/js/co.test.config.js
+ENV=`grep 'testConfig.env' $TEST_CONFIG | sed "s/testConfig\.env \= '\([a-z]*\)';/\1/"`
+GRUNT_DIR=$ROOT_DIR/$TEST_DIR/node_modules/grunt-cli
+GRUNT_FILE=$ROOT_DIR/$TEST_DIR/Gruntfile.js
+force=false
 
-if [ $ENV = "'prod'" ]; then
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --force) force=true; shift 1;;
+
+    -*) echo "unknown option: $1" >&2; exit 1;;
+    *) die "unrecognized argument: $1"; shift 1;;
+  esac
+done
+
+if [ $ENV == "prod" ] || [ "$force" == true ]; then
     if [ -d "$GRUNT_DIR" ]; then
         ulimit -n 2054
         $GRUNT_DIR/bin/grunt --gruntfile $GRUNT_FILE run


### PR DESCRIPTION
- fixed issue with getting the test enviroment.
grep -o is not supported with older versions
- added support to execute the run_test.sh script from
both top of the dir and as well webroot/test/ui directory
- added option to execute tests when the compiled env is not prod.
pass --force to run_tests.sh to enable.

Change-Id: I261a44ff2b45edce616cd8b397ed91df182b7b43