### PR TITLE
Closes-Bug:#1559222

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ node_modules
 **/feature.list.js
 **/rolemap.api.js
 webroot/common/api/package.js
-webroot/build/sm.build.config.js

--- a/webroot/build/.gitignore
+++ b/webroot/build/.gitignore
@@ -1,0 +1,1 @@
+sm.build.config.js

--- a/webroot/build/sm.build.config.js
+++ b/webroot/build/sm.build.config.js
@@ -1,4 +1,0 @@
-/*
- * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
- */
-({})


### PR DESCRIPTION
Issue is generated files are shown in git diff command.

As the  *.build.config.js files (* is core/controller/storage/sm) are checkedin, adding to .gitignore wont help.
Hence removed from corresponding repos which make files as untracked for which gitignore is applicable.

In case of controller, storage and server manager repos build directory consists build.config.file alone, so removing
this file from repo deletes the directory, hence added the .gitignore file in build directory in all the repos and
added the build.config.js in corresponding .gitignore file.

Change-Id: I5c0cc5bcfa3e48769fedab6906cd147f786052ba